### PR TITLE
fixing bug where in getPhrasesFromTranscript function where last phra…

### DIFF
--- a/src/srtUtils.py
+++ b/src/srtUtils.py
@@ -215,7 +215,11 @@ def getPhrasesFromTranscript( transcript ):
 			phrase = newPhrase()
 			nPhrase = True
 			x = 0
-			
+	
+	# if there are any words in the final phrase add to phrases  
+	if(len(phrase["words"]) > 0):
+		phrases.append(phrase)	
+				
 	return phrases
 	
 

--- a/tools/srtUtils.py
+++ b/tools/srtUtils.py
@@ -215,7 +215,11 @@ def getPhrasesFromTranscript( transcript ):
 			phrase = newPhrase()
 			nPhrase = True
 			x = 0
-			
+	
+	# if there are any words in the final phrase add to phrases  
+	if(len(phrase["words"]) > 0):
+		phrases.append(phrase)	
+				
 	return phrases
 	
 

--- a/tools/webvttUtils.py
+++ b/tools/webvttUtils.py
@@ -138,6 +138,10 @@ def getPhrasesFromTranscript( transcript ):
 			phrase = newPhrase()
 			nPhrase = True
 			x = 0
+	
+	# if there are any words in the final phrase add to phrases  
+	if(len(phrase["words"]) > 0):
+		phrases.append(phrase)	
 			
 	return phrases
 	


### PR DESCRIPTION
…se gets left out of vtt file

*Issue #, if available:*
https://github.com/aws-samples/aws-transcribe-captioning-tools/issues/2

*Description of changes:*
before returning the phrases in getPhrasesFromTranscript check to see if the phrase has any words in it and if so add that phrase to the phrases. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
