### PR TITLE
getPhrasesFromTranscript leaves out phrase re-edit

### DIFF
--- a/src/srtUtils.py
+++ b/src/srtUtils.py
@@ -185,6 +185,7 @@ def getPhrasesFromTranscript( transcript ):
 	nPhrase = True
 	x = 0
 	c = 0
+	lastEndTime = ""
 
 	print "==> Creating phrases from transcript..."
 
@@ -195,6 +196,7 @@ def getPhrasesFromTranscript( transcript ):
 			if item["type"] == "pronunciation":
 				phrase["start_time"] = getTimeCode( float(item["start_time"]) )
 				nPhrase = False
+				lastEndTime =  getTimeCode( float(item["end_time"]) )
 			c+= 1
 		else:	
 			# get the end_time if the item is a pronuciation and store it
@@ -218,6 +220,8 @@ def getPhrasesFromTranscript( transcript ):
 	
 	# if there are any words in the final phrase add to phrases  
 	if(len(phrase["words"]) > 0):
+		if phrase['end_time'] == '':
+            		phrase['end_time'] = lastEndTime
 		phrases.append(phrase)	
 				
 	return phrases


### PR DESCRIPTION
If just there are 1 word in las phrase not fill the end-time , I propose this change to fix the bug

*Issue #, if available:*
#2 
*Description of changes:*
I save the endtime in a variable and if it's not filled in the last phrase I use the value stored in this variable to fill

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
